### PR TITLE
Remove overly restrictive REST auth filter blocking all non-Vercel or…

### DIFF
--- a/InPursuit.php
+++ b/InPursuit.php
@@ -104,14 +104,6 @@
 		}
 	} );
 
-	add_filter( 'rest_authentication_errors', function( $errors ){
-		$request_server = $_SERVER['REMOTE_ADDR'];
-    $origin = get_http_origin();
-    if ($origin !== 'https://inpursuit.vercel.app') return new WP_Error('forbidden_access', $origin, array(
-        'status' => 403
-    ));
-    return $errors;
-	} );
 	/* CORS ENABLED FOR THE TEST VUE SITE */
 
 


### PR DESCRIPTION
…igins

The filter was blocking direct browser access and server requests to all REST endpoints. CORS is handled by the init action added previously.